### PR TITLE
feat: Improve design system documentation preview

### DIFF
--- a/apps/preview/content/components/button.md
+++ b/apps/preview/content/components/button.md
@@ -1,0 +1,14 @@
+---
+title: Button
+description: A standard button element.
+---
+
+## HTML Snippet
+
+```html
+<button class="ody-button">Click Me</button>
+```
+
+## Usage Notes
+
+Apply the `.ody-button` class to a `<button>` element to get the default button styling. See `packages/styles/src/components/_buttons.scss` for style definitions.

--- a/apps/preview/content/components/typography.md
+++ b/apps/preview/content/components/typography.md
@@ -1,0 +1,19 @@
+---
+title: Typography Showcase
+description: Demonstrates the basic typographic elements available, including different heading levels and paragraph text. These styles are generally applied globally or within container elements.
+---
+
+## HTML Snippet
+
+```html
+<div class="ody-container">
+  <h1>Heading 1</h1>
+  <h2>Heading 2</h2>
+  <h3>Heading 3</h3>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+```
+
+## Usage Notes
+
+The `ody-container` class can be used to provide standard width and padding for content sections. Headings and paragraphs will inherit global styles.

--- a/apps/preview/pages/components.html
+++ b/apps/preview/pages/components.html
@@ -1,2 +1,5 @@
-<h1>Components</h1>
-<p>Learn more about our project.</p>
+<ul id="component-list"></ul>
+<div id="component-display">
+  <div id="component-preview"></div>
+  <div id="component-docs"></div>
+</div>

--- a/apps/preview/shared/components/aside.html
+++ b/apps/preview/shared/components/aside.html
@@ -1,5 +1,6 @@
 <nav class="aside__nav">
   <a class="aside__link" href="#/" data-link>Home</a>
-  <a class="aside__link"  href="#/components" data-link>Components</a>
+  <a class="aside__link" href="pages/components.html">Components</a>
+  <a class="aside__link"  href="#/components" data-link>Components (Legacy)</a>
   <a class="aside__link aside__sub-link"  href="#/button" data-link>Button</a>
 </nav>

--- a/apps/preview/shared/js/main.js
+++ b/apps/preview/shared/js/main.js
@@ -16,5 +16,70 @@ window.onload = async () => {
 
   fetch('README.md')
     .then(response => response.text())
-    .then(result => document.getElementById('ody-markerd').innerHTML = marked.parse(result));
+    .then(result => {
+      const mainContentElement = document.getElementById('ody-markerd');
+      if (mainContentElement) {
+        mainContentElement.innerHTML = marked.parse(result);
+      }
+    });
+  loadComponentsPage(); // Add this call for the new functionality
 }
+
+// --- New code for components page ---
+function loadComponentsPage() {
+  const componentList = document.getElementById('component-list');
+  const componentPreview = document.getElementById('component-preview');
+  const componentDocs = document.getElementById('component-docs');
+
+  // Only run if the component list element exists on the page
+  if (!componentList) {
+    return;
+  }
+
+  const componentDocFiles = ['typography.md', 'button.md'];
+  const baseDocPath = 'content/components/'; // Relative to the preview app root
+
+  componentDocFiles.forEach(docFile => {
+    const listItem = document.createElement('li');
+    // Derive name: "typography.md" -> "Typography"
+    const componentName = docFile.replace('.md', '').replace(/^\w/, c => c.toUpperCase());
+    listItem.textContent = componentName;
+    listItem.style.cursor = 'pointer'; // Make it look clickable
+
+    listItem.addEventListener('click', () => {
+      const filePath = baseDocPath + docFile;
+      fetch(filePath)
+        .then(response => {
+          if (!response.ok) {
+            throw new Error(`Failed to fetch ${filePath}: ${response.statusText}`);
+          }
+          return response.text();
+        })
+        .then(markdownContent => {
+          // Extract HTML snippet
+          const htmlSnippetMatch = markdownContent.match(/```html\n([^`]+)\n```/);
+          let htmlToPreview = '';
+          if (htmlSnippetMatch && htmlSnippetMatch[1]) {
+            htmlToPreview = htmlSnippetMatch[1];
+          }
+
+          if (componentPreview) {
+            componentPreview.innerHTML = htmlToPreview;
+          }
+
+          if (componentDocs) {
+            // Render full markdown (or markdown without the snippet)
+            // For simplicity, rendering full markdown for now.
+            componentDocs.innerHTML = marked.parse(markdownContent);
+          }
+        })
+        .catch(error => {
+          console.error('Error loading component:', error);
+          if (componentPreview) componentPreview.innerHTML = '<p>Error loading preview.</p>';
+          if (componentDocs) componentDocs.innerHTML = '<p>Error loading documentation.</p>';
+        });
+    });
+    componentList.appendChild(listItem);
+  });
+}
+// --- End of new code for components page ---

--- a/button_example.html
+++ b/button_example.html
@@ -1,0 +1,1 @@
+<button class="ody-button">Click Me</button>

--- a/packages/styles/src/components.scss
+++ b/packages/styles/src/components.scss
@@ -1,0 +1,3 @@
+// packages/styles/src/components.scss
+
+@forward 'components/buttons';

--- a/packages/styles/src/components/_buttons.scss
+++ b/packages/styles/src/components/_buttons.scss
@@ -1,0 +1,8 @@
+// packages/styles/src/components/_buttons.scss
+
+.ody-button {
+  padding: 8px 16px;
+  border: 1px solid #ccc;
+  background-color: #f0f0f0;
+  cursor: pointer;
+}

--- a/typography_showcase.html
+++ b/typography_showcase.html
@@ -1,0 +1,6 @@
+<div class="ody-container">
+  <h1>Heading 1</h1>
+  <h2>Heading 2</h2>
+  <h3>Heading 3</h3>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
+</div>


### PR DESCRIPTION
This commit introduces several enhancements to the app preview for the design system documentation:

1.  **Initial Component Definitions:**
    *   Added basic HTML structure for a "Typography Showcase" and a "Button" example.
    *   Created initial SCSS for the button component (`.ody-button`) in `packages/styles/src/components/_buttons.scss` and updated `components.scss` to import it.

2.  **Component Markdown Documentation:**
    *   Created Markdown files (`typography.md`, `button.md`) in a new `apps/preview/content/components/` directory.
    *   These files include descriptions, HTML snippets for preview, and usage notes.

3.  **Dynamic Preview System:**
    *   Modified `apps/preview/pages/components.html` to provide a structured layout for component documentation.
    *   Enhanced `apps/preview/shared/js/main.js` to:
        *   List available components from the Markdown files.
        *   Allow you to select a component.
        *   Dynamically render a live HTML preview of the component's snippet.
        *   Display the component's documentation parsed from Markdown using `marked.js`.

4.  **Navigation Update:**
    *   Added a direct link to the new "Components" documentation page in the side navigation (`apps/preview/shared/components/aside.html`).

These changes establish a foundational system for documenting and previewing design system components, making it easier for you to understand and utilize them.