### PR TITLE
Add Zeus, Hades and Poseidon token themes

### DIFF
--- a/apps/preview/shared/components/header.html
+++ b/apps/preview/shared/components/header.html
@@ -35,5 +35,11 @@
           </g>
       </svg>
     </button>
+    <select id="theme-select" title="Select theme" aria-label="Theme selector">
+      <option value="core">Core</option>
+      <option value="zeus">Zeus</option>
+      <option value="hades">Hades</option>
+      <option value="poseidon">Poseidon</option>
+    </select>
   </div>
 </nav>

--- a/apps/preview/shared/js/main.js
+++ b/apps/preview/shared/js/main.js
@@ -2,6 +2,7 @@ import { loadComponents } from './load-components.js';
 
 import { render } from './render.js';
 import { onLoadThemeToggle } from './theme-toggle.js';
+import { onLoadThemeSelector } from './theme-selector.js';
 import { onLoadAside } from './aside.js';
 
 import '../../../../dist/tokens/core/tokens.css';
@@ -12,6 +13,7 @@ window.onload = async () => {
   await loadComponents();
   onLoadAside();
   onLoadThemeToggle();
+  onLoadThemeSelector();
 
   document.addEventListener('click', (e) => {
     const item = e.target.closest('.icons-gallery');

--- a/apps/preview/shared/js/theme-selector.js
+++ b/apps/preview/shared/js/theme-selector.js
@@ -1,0 +1,34 @@
+const themeStorageKey = 'odyspace-theme';
+
+const getThemePreference = () => {
+  return localStorage.getItem(themeStorageKey) || 'core';
+};
+
+const theme = {
+  value: getThemePreference(),
+};
+
+const applyTheme = () => {
+  const root = document.documentElement;
+  const themes = ['core', 'hades', 'poseidon', 'zeus'];
+  themes.forEach(t => root.classList.remove(`odyspace-theme-${t}`));
+  root.classList.add(`odyspace-theme-${theme.value}`);
+
+  const select = document.querySelector('#theme-select');
+  if (select) select.value = theme.value;
+};
+
+const setPreference = () => {
+  localStorage.setItem(themeStorageKey, theme.value);
+  applyTheme();
+};
+
+const onChange = (e) => {
+  theme.value = e.target.value;
+  setPreference();
+};
+
+export function onLoadThemeSelector() {
+  applyTheme();
+  document.querySelector('#theme-select')?.addEventListener('change', onChange);
+}

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -68,6 +68,7 @@ A **Foundation** é o núcleo que contém valores fixos e independentes de temas
 O **Theme** contém variações que personalizam os valores da Foundation com base em um contexto, como:
 - Tema claro ou escuro
 - Temas personalizados para diferentes marcas
+- Zeus, Hades e Poseidon
 
 ---
 

--- a/packages/tokens/src/tokens/themes/hades/color.json
+++ b/packages/tokens/src/tokens/themes/hades/color.json
@@ -1,0 +1,42 @@
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "{color_ref.gray.900.value}", "theme": "hades" },
+      "on_primary": { "value": "{color_ref.gray.50.value}", "theme": "hades" },
+      "secondary": { "value": "{color_ref.red.700.value}", "theme": "hades" },
+      "on_secondary": { "value": "{color_ref.red.50.value}", "theme": "hades" },
+      "tertiary": { "value": "{color_ref.purple.700.value}", "theme": "hades" },
+      "on_tertiary": { "value": "{color_ref.purple.50.value}", "theme": "hades" }
+    },
+    "surface": {
+      "low": { "value": "{color_ref.gray.800.value}", "theme": "hades" },
+      "on_low": { "value": "{color_ref.gray.100.value}", "theme": "hades" },
+      "base": { "value": "{color_ref.gray.900.value}", "theme": "hades" },
+      "on_base": { "value": "{color_ref.gray.50.value}", "theme": "hades" },
+      "high": { "value": "{color_ref.gray.700.value}", "theme": "hades" },
+      "on_high": { "value": "{color_ref.gray.50.value}", "theme": "hades" },
+      "container": {
+        "lowest": { "value": "{color_ref.gray.700.value}", "theme": "hades" },
+        "on_lowest": { "value": "{color_ref.gray.100.value}", "theme": "hades" },
+        "low": { "value": "{color_ref.gray.800.value}", "theme": "hades" },
+        "on_low": { "value": "{color_ref.gray.100.value}", "theme": "hades" },
+        "neutral": { "value": "{color_ref.gray.600.value}", "theme": "hades" },
+        "on_neutral": { "value": "{color_ref.gray.50.value}", "theme": "hades" },
+        "high": { "value": "{color_ref.gray.700.value}", "theme": "hades" },
+        "on_high": { "value": "{color_ref.gray.50.value}", "theme": "hades" },
+        "highest": { "value": "{color_ref.black.value}", "theme": "hades" },
+        "on_highest": { "value": "{color_ref.gray.50.value}", "theme": "hades" }
+      }
+    },
+    "feedback": {
+      "success": { "value": "{color_ref.green.500.value}", "theme": "hades" },
+      "on_success": { "value": "{color_ref.green.50.value}", "theme": "hades" },
+      "warning": { "value": "{color_ref.yellow.500.value}", "theme": "hades" },
+      "on_warning": { "value": "{color_ref.yellow.50.value}", "theme": "hades" },
+      "error": { "value": "{color_ref.red.500.value}", "theme": "hades" },
+      "on_error": { "value": "{color_ref.red.50.value}", "theme": "hades" },
+      "info": { "value": "{color_ref.purple.500.value}", "theme": "hades" },
+      "on_info": { "value": "{color_ref.purple.50.value}", "theme": "hades" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/hades/component.json
+++ b/packages/tokens/src/tokens/themes/hades/component.json
@@ -1,0 +1,12 @@
+{
+  "component": {
+    "icon": {
+      "color": {
+        "base": { "value": "{color.surface.on_base.value}", "theme": "hades" }
+      }
+    },
+    "button": {
+      "color": { "value": "{color.brand.primary.value}", "theme": "hades" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/hades/typography.json
+++ b/packages/tokens/src/tokens/themes/hades/typography.json
@@ -1,0 +1,38 @@
+{
+  "typography": {
+    "family": {
+      "base": { "value": "{font.family.roboto.name.value}", "theme": "hades" },
+      "highlight": { "value": "{font.family.poppins.name.value}", "theme": "hades" }
+    },
+    "size": {
+      "50": { "value": "{font.size.50.value}", "theme": "hades" },
+      "75": { "value": "{font.size.75.value}", "theme": "hades" },
+      "100": { "value": "{font.size.100.value}", "theme": "hades" },
+      "200": { "value": "{font.size.200.value}", "theme": "hades" },
+      "300": { "value": "{font.size.300.value}", "theme": "hades" },
+      "400": { "value": "{font.size.400.value}", "theme": "hades" },
+      "500": { "value": "{font.size.500.value}", "theme": "hades" },
+      "600": { "value": "{font.size.600.value}", "theme": "hades" },
+      "700": { "value": "{font.size.700.value}", "theme": "hades" },
+      "800": { "value": "{font.size.800.value}", "theme": "hades" },
+      "900": { "value": "{font.size.900.value}", "theme": "hades" },
+      "1000": { "value": "{font.size.1000.value}", "theme": "hades" },
+      "1100": { "value": "{font.size.1100.value}", "theme": "hades" },
+      "1200": { "value": "{font.size.1200.value}", "theme": "hades" },
+      "1300": { "value": "{font.size.1300.value}", "theme": "hades" }
+    },
+    "weight": {
+      "01": { "value": "{font.weight.300.value}", "type": "hades" },
+      "02": { "value": "{font.weight.400.value}", "type": "hades" },
+      "03": { "value": "{font.weight.700.value}", "type": "hades" }
+    },
+    "lineHeight": {
+      "50": { "value": "{font.lineHeight.50.value}", "theme": "hades" },
+      "100": { "value": "{font.lineHeight.100.value}", "theme": "hades" },
+      "200": { "value": "{font.lineHeight.200.value}", "theme": "hades" }
+    },
+    "letterSpacing": {
+      "0": { "value": "{font.letterSpacing.0.value}", "theme": "hades" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/poseidon/color.json
+++ b/packages/tokens/src/tokens/themes/poseidon/color.json
@@ -1,0 +1,42 @@
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "{color_ref.cyan.600.value}", "theme": "poseidon" },
+      "on_primary": { "value": "{color_ref.cyan.50.value}", "theme": "poseidon" },
+      "secondary": { "value": "{color_ref.blue.700.value}", "theme": "poseidon" },
+      "on_secondary": { "value": "{color_ref.blue.50.value}", "theme": "poseidon" },
+      "tertiary": { "value": "{color_ref.green.500.value}", "theme": "poseidon" },
+      "on_tertiary": { "value": "{color_ref.green.50.value}", "theme": "poseidon" }
+    },
+    "surface": {
+      "low": { "value": "{color_ref.gray.50.value}", "theme": "poseidon" },
+      "on_low": { "value": "{color_ref.gray.500.value}", "theme": "poseidon" },
+      "base": { "value": "{color_ref.gray.100.value}", "theme": "poseidon" },
+      "on_base": { "value": "{color_ref.gray.900.value}", "theme": "poseidon" },
+      "high": { "value": "{color_ref.gray.400.value}", "theme": "poseidon" },
+      "on_high": { "value": "{color_ref.gray.50.value}", "theme": "poseidon" },
+      "container": {
+        "lowest": { "value": "{color_ref.gray.300.value}", "theme": "poseidon" },
+        "on_lowest": { "value": "{color_ref.gray.500.value}", "theme": "poseidon" },
+        "low": { "value": "{color_ref.gray.400.value}", "theme": "poseidon" },
+        "on_low": { "value": "{color_ref.gray.50.value}", "theme": "poseidon" },
+        "neutral": { "value": "{color_ref.gray.200.value}", "theme": "poseidon" },
+        "on_neutral": { "value": "{color_ref.gray.500.value}", "theme": "poseidon" },
+        "high": { "value": "{color_ref.gray.500.value}", "theme": "poseidon" },
+        "on_high": { "value": "{color_ref.gray.50.value}", "theme": "poseidon" },
+        "highest": { "value": "{color_ref.gray.600.value}", "theme": "poseidon" },
+        "on_highest": { "value": "{color_ref.gray.50.value}", "theme": "poseidon" }
+      }
+    },
+    "feedback": {
+      "success": { "value": "{color_ref.green.500.value}", "theme": "poseidon" },
+      "on_success": { "value": "{color_ref.green.50.value}", "theme": "poseidon" },
+      "warning": { "value": "{color_ref.yellow.500.value}", "theme": "poseidon" },
+      "on_warning": { "value": "{color_ref.yellow.50.value}", "theme": "poseidon" },
+      "error": { "value": "{color_ref.red.500.value}", "theme": "poseidon" },
+      "on_error": { "value": "{color_ref.red.50.value}", "theme": "poseidon" },
+      "info": { "value": "{color_ref.cyan.600.value}", "theme": "poseidon" },
+      "on_info": { "value": "{color_ref.cyan.50.value}", "theme": "poseidon" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/poseidon/component.json
+++ b/packages/tokens/src/tokens/themes/poseidon/component.json
@@ -1,0 +1,12 @@
+{
+  "component": {
+    "icon": {
+      "color": {
+        "base": { "value": "{color.surface.on_base.value}", "theme": "poseidon" }
+      }
+    },
+    "button": {
+      "color": { "value": "{color.brand.primary.value}", "theme": "poseidon" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/poseidon/typography.json
+++ b/packages/tokens/src/tokens/themes/poseidon/typography.json
@@ -1,0 +1,38 @@
+{
+  "typography": {
+    "family": {
+      "base": { "value": "{font.family.roboto.name.value}", "theme": "poseidon" },
+      "highlight": { "value": "{font.family.poppins.name.value}", "theme": "poseidon" }
+    },
+    "size": {
+      "50": { "value": "{font.size.50.value}", "theme": "poseidon" },
+      "75": { "value": "{font.size.75.value}", "theme": "poseidon" },
+      "100": { "value": "{font.size.100.value}", "theme": "poseidon" },
+      "200": { "value": "{font.size.200.value}", "theme": "poseidon" },
+      "300": { "value": "{font.size.300.value}", "theme": "poseidon" },
+      "400": { "value": "{font.size.400.value}", "theme": "poseidon" },
+      "500": { "value": "{font.size.500.value}", "theme": "poseidon" },
+      "600": { "value": "{font.size.600.value}", "theme": "poseidon" },
+      "700": { "value": "{font.size.700.value}", "theme": "poseidon" },
+      "800": { "value": "{font.size.800.value}", "theme": "poseidon" },
+      "900": { "value": "{font.size.900.value}", "theme": "poseidon" },
+      "1000": { "value": "{font.size.1000.value}", "theme": "poseidon" },
+      "1100": { "value": "{font.size.1100.value}", "theme": "poseidon" },
+      "1200": { "value": "{font.size.1200.value}", "theme": "poseidon" },
+      "1300": { "value": "{font.size.1300.value}", "theme": "poseidon" }
+    },
+    "weight": {
+      "01": { "value": "{font.weight.300.value}", "type": "poseidon" },
+      "02": { "value": "{font.weight.400.value}", "type": "poseidon" },
+      "03": { "value": "{font.weight.700.value}", "type": "poseidon" }
+    },
+    "lineHeight": {
+      "50": { "value": "{font.lineHeight.50.value}", "theme": "poseidon" },
+      "100": { "value": "{font.lineHeight.100.value}", "theme": "poseidon" },
+      "200": { "value": "{font.lineHeight.200.value}", "theme": "poseidon" }
+    },
+    "letterSpacing": {
+      "0": { "value": "{font.letterSpacing.0.value}", "theme": "poseidon" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/zeus/color.json
+++ b/packages/tokens/src/tokens/themes/zeus/color.json
@@ -1,0 +1,42 @@
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "{color_ref.yellow.500.value}", "theme": "zeus" },
+      "on_primary": { "value": "{color_ref.yellow.50.value}", "theme": "zeus" },
+      "secondary": { "value": "{color_ref.blue.500.value}", "theme": "zeus" },
+      "on_secondary": { "value": "{color_ref.blue.50.value}", "theme": "zeus" },
+      "tertiary": { "value": "{color_ref.orange.500.value}", "theme": "zeus" },
+      "on_tertiary": { "value": "{color_ref.orange.50.value}", "theme": "zeus" }
+    },
+    "surface": {
+      "low": { "value": "{color_ref.gray.50.value}", "theme": "zeus" },
+      "on_low": { "value": "{color_ref.gray.500.value}", "theme": "zeus" },
+      "base": { "value": "{color_ref.gray.100.value}", "theme": "zeus" },
+      "on_base": { "value": "{color_ref.gray.900.value}", "theme": "zeus" },
+      "high": { "value": "{color_ref.gray.400.value}", "theme": "zeus" },
+      "on_high": { "value": "{color_ref.gray.50.value}", "theme": "zeus" },
+      "container": {
+        "lowest": { "value": "{color_ref.gray.300.value}", "theme": "zeus" },
+        "on_lowest": { "value": "{color_ref.gray.500.value}", "theme": "zeus" },
+        "low": { "value": "{color_ref.gray.400.value}", "theme": "zeus" },
+        "on_low": { "value": "{color_ref.gray.50.value}", "theme": "zeus" },
+        "neutral": { "value": "{color_ref.gray.200.value}", "theme": "zeus" },
+        "on_neutral": { "value": "{color_ref.gray.500.value}", "theme": "zeus" },
+        "high": { "value": "{color_ref.gray.500.value}", "theme": "zeus" },
+        "on_high": { "value": "{color_ref.gray.50.value}", "theme": "zeus" },
+        "highest": { "value": "{color_ref.gray.600.value}", "theme": "zeus" },
+        "on_highest": { "value": "{color_ref.gray.50.value}", "theme": "zeus" }
+      }
+    },
+    "feedback": {
+      "success": { "value": "{color_ref.green.500.value}", "theme": "zeus" },
+      "on_success": { "value": "{color_ref.green.50.value}", "theme": "zeus" },
+      "warning": { "value": "{color_ref.yellow.500.value}", "theme": "zeus" },
+      "on_warning": { "value": "{color_ref.yellow.50.value}", "theme": "zeus" },
+      "error": { "value": "{color_ref.red.500.value}", "theme": "zeus" },
+      "on_error": { "value": "{color_ref.red.50.value}", "theme": "zeus" },
+      "info": { "value": "{color_ref.blue.500.value}", "theme": "zeus" },
+      "on_info": { "value": "{color_ref.blue.50.value}", "theme": "zeus" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/zeus/component.json
+++ b/packages/tokens/src/tokens/themes/zeus/component.json
@@ -1,0 +1,12 @@
+{
+  "component": {
+    "icon": {
+      "color": {
+        "base": { "value": "{color.surface.on_base.value}", "theme": "zeus" }
+      }
+    },
+    "button": {
+      "color": { "value": "{color.brand.primary.value}", "theme": "zeus" }
+    }
+  }
+}

--- a/packages/tokens/src/tokens/themes/zeus/typography.json
+++ b/packages/tokens/src/tokens/themes/zeus/typography.json
@@ -1,0 +1,38 @@
+{
+  "typography": {
+    "family": {
+      "base": { "value": "{font.family.roboto.name.value}", "theme": "zeus" },
+      "highlight": { "value": "{font.family.poppins.name.value}", "theme": "zeus" }
+    },
+    "size": {
+      "50": { "value": "{font.size.50.value}", "theme": "zeus" },
+      "75": { "value": "{font.size.75.value}", "theme": "zeus" },
+      "100": { "value": "{font.size.100.value}", "theme": "zeus" },
+      "200": { "value": "{font.size.200.value}", "theme": "zeus" },
+      "300": { "value": "{font.size.300.value}", "theme": "zeus" },
+      "400": { "value": "{font.size.400.value}", "theme": "zeus" },
+      "500": { "value": "{font.size.500.value}", "theme": "zeus" },
+      "600": { "value": "{font.size.600.value}", "theme": "zeus" },
+      "700": { "value": "{font.size.700.value}", "theme": "zeus" },
+      "800": { "value": "{font.size.800.value}", "theme": "zeus" },
+      "900": { "value": "{font.size.900.value}", "theme": "zeus" },
+      "1000": { "value": "{font.size.1000.value}", "theme": "zeus" },
+      "1100": { "value": "{font.size.1100.value}", "theme": "zeus" },
+      "1200": { "value": "{font.size.1200.value}", "theme": "zeus" },
+      "1300": { "value": "{font.size.1300.value}", "theme": "zeus" }
+    },
+    "weight": {
+      "01": { "value": "{font.weight.300.value}", "type": "zeus" },
+      "02": { "value": "{font.weight.400.value}", "type": "zeus" },
+      "03": { "value": "{font.weight.700.value}", "type": "zeus" }
+    },
+    "lineHeight": {
+      "50": { "value": "{font.lineHeight.50.value}", "theme": "zeus" },
+      "100": { "value": "{font.lineHeight.100.value}", "theme": "zeus" },
+      "200": { "value": "{font.lineHeight.200.value}", "theme": "zeus" }
+    },
+    "letterSpacing": {
+      "0": { "value": "{font.letterSpacing.0.value}", "theme": "zeus" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Zeus, Hades and Poseidon design token themes with custom color palettes
- mention the new themes in tokens README
- add a theme selector in the preview header to switch token themes

## Testing
- `npm test` *(fails: nx not found)*


------
https://chatgpt.com/codex/tasks/task_e_68445d50ab588325b18d921f3426ddd7